### PR TITLE
[리팩토링] 캘린더 api 형식 변경(Request: user_id, baby_id 추가, Response: year, month ,time, information 추가) & s3 이미지 다운로드 로직

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ LANGCHAIN_TRACING_V2=true
 LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 LANGCHAIN_API_KEY=your-api-key
 LANGCHAIN_PROJECT=your-project-name
+
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+AWS_REGION=your-region
+AWS_BUCKET_NAME=your-bucket-name
 ```
 
 - docker image build

--- a/app/api/calendar/models.py
+++ b/app/api/calendar/models.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 class Activity(BaseModel):
     name: str
     time: Optional[str] = Field(default=None)
-    location: str
+    infomation: str
 
 
 class Event(BaseModel):

--- a/app/api/calendar/models.py
+++ b/app/api/calendar/models.py
@@ -1,21 +1,33 @@
 from pydantic import BaseModel
 from langchain_core.pydantic_v1 import Field
-from typing import List
+from typing import List, Optional
+
+
+class Activity(BaseModel):
+    name: str
+    time: Optional[str] = Field(default=None)
+    location: str
 
 
 class Event(BaseModel):
-    date: str = Field(description="Day of the event datetime format DD(1-31)")
-    activities: List[str] = Field(
-        description="Concise list of activities for this date, including only essential information"
-    )
+    date: str = Field(description="Day of the event (1-31)")
+    activities: List[Activity]
 
 
 class MonthlySchedule(BaseModel):
-    events: List[Event] = Field(description="List of events for each date")
-    etc: str = Field(
-        description="Additional information that does not fit into the event list"
+    year: Optional[str] = Field(default=None)
+    month: str
+    events: List[Event]
+    etc: Optional[str] = Field(
+        description="Additional information that does not fit into the event list",
+        default=None,
     )
+    user_id: str
+    baby_id: str
 
 
+# 이미지 업로드 모델(user_id, baby_id, image_path)
 class ImageInput(BaseModel):
+    user_id: str
+    baby_id: str
     image_path: str

--- a/app/api/calendar/prompts/calendar_betterocr_ver2.txt
+++ b/app/api/calendar/prompts/calendar_betterocr_ver2.txt
@@ -1,0 +1,18 @@
+Organize the OCR results of a monthly event schedule as follows:
+
+1. Extract activities for each date, splitting by '\n'.
+2. Extract only the day (DD) from dates and normalize to two-digit format.
+3. Summarize each activity concisely, including only essential information.
+4. Group activities by date.
+5. Include any additional information that doesn't fit into specific dates in the 'etc' field.
+
+Guidelines:
+- Date format should be 'DD' (two-digit day only, e.g., '06', '13', '30').
+- Summarize activities briefly while retaining crucial details.
+- Omit repetitive or non-essential information.
+- Always answer in Korean.
+OCR result: {ocr_result}
+
+Format instructions: {format_instructions}
+
+Provide the organized schedule based on these guidelines.

--- a/app/api/calendar/utils/s3_util.py
+++ b/app/api/calendar/utils/s3_util.py
@@ -1,0 +1,38 @@
+# s3 연동
+import boto3
+import tempfile
+from botocore.exceptions import ClientError
+import uuid
+from urllib.parse import urlparse, unquote
+import os
+
+
+# s3 클라이언트 설정
+def set_s3_client():
+    s3_client = boto3.client(
+        "s3",
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+        region_name=os.getenv("AWS_REGION_NAME"),
+    )
+    return s3_client
+
+
+# s3 파일 이름 파싱
+def parse_s3_url(url):
+    # URL 파싱
+    parsed_url = urlparse(url)
+
+    # 경로에서 파일 이름 추출
+    file_name = os.path.basename(unquote(parsed_url.path))
+
+    # 타임스탬프와 원본 파일 이름 분리 (옵션)
+    parts = file_name.split("-", 1)
+    timestamp = parts[0] if len(parts) > 1 else None
+    original_file_name = parts[1] if len(parts) > 1 else file_name
+
+    return {
+        "full_file_name": file_name,
+        "timestamp": timestamp,
+        "original_file_name": original_file_name,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -174,3 +174,4 @@ websockets==13.0.1
 wget==3.2
 yarl==1.9.4
 zipp==3.20.1
+boto3==1.35.14


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[Branch][feature/calendar-dev]

### 💡 작업동기
- 캘린더 api에서 사용해야 하는 user_id, baby_id input 데이터 추가 필요
- api 출력에서 이벤트별 시간 정보 필요
- s3에 저장된 이미지 다운로드 받아 추론 후 삭제하는 로직 추가 필요

### 🔑 주요 변경사항
- 캘린더 api 입/출력 형식 변경
- s3에 저장된 이미지 다운로드 받아 추론 후 삭제하는 로직 추가

### 🏞 스크린샷
<img width="518" alt="image" src="https://github.com/user-attachments/assets/127bd48c-9962-4cde-aea8-636efe73d5ab">
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/f4f5743a-dc9a-4d76-9d81-a2d5b2c0c9ba">


### 관련 이슈
- #25 
- 가정통신문에서 없을 수 있는 정보들은 Optional로 처리하여 정보가 없을 시 null값을 생성하도록 하였습니다.

### 💬리뷰 요구사항(선택)
