### PR TITLE
[리팩토링]동화생성 생성 삽화 url 짧게 만들기

### DIFF
--- a/app/api/fairytale/utils/fairytale_image_utils.py
+++ b/app/api/fairytale/utils/fairytale_image_utils.py
@@ -1,4 +1,5 @@
 from openai import OpenAI
+import pyshorteners
 
 
 def generate_image(client, context):
@@ -14,3 +15,9 @@ def generate_image(client, context):
     # 생성된 이미지의 URL을 저장
     image_url = response.data[0].url
     return image_url
+
+
+def shorten_url(long_url):
+    s = pyshorteners.Shortener()
+    short_url = s.tinyurl.short(long_url)
+    return short_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -175,3 +175,4 @@ wget==3.2
 yarl==1.9.4
 zipp==3.20.1
 boto3==1.35.14
+pyshorteners==1.0.1


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[Branch][feature/fairytale-gen-url-convert-shrot-url]

### 💡 작업동기
- 동화생성 생성 삽화 url이 255자가 넘어 DB 저장 시 에러 발생

### 🔑 주요 변경사항
- 동화생성 생성 삽화 url 짧게 변환(pyshorteners 모듈 이용)

### 🏞 스크린샷
스크린샷을 첨부해주세요.

### 관련 이슈


### 💬리뷰 요구사항(선택)

