### PR TITLE
[기능개선]알림장 요약 API 유효하지 않은 입력 알림장 예외처리 & Response 값 키워드 내용 Optional None

### DIFF
--- a/app/api/babydiary/babydiary.py
+++ b/app/api/babydiary/babydiary.py
@@ -56,6 +56,10 @@ async def process_report(diary_input: DiaryInput):
         notice = diary_input.report
 
         report = chain.invoke({"report": notice})
+        if report["is_valid"] == False:
+            raise HTTPException(status_code=400, detail="Invalid daycare report content")
+        
+        report.pop('is_valid', None)
         result = chain2.invoke(report)
         report["diary"] = result
         report.update({"user_id": user_id, "baby_id": baby_id, "role": "child"})

--- a/app/api/babydiary/models.py
+++ b/app/api/babydiary/models.py
@@ -1,15 +1,13 @@
 from pydantic import BaseModel, Field
-from typing import List
-
+from typing import List, Optional
 
 class DaycareReport(BaseModel):
-    name: str = Field(description="Child's name")
-    emotion: str = Field(description="Child's overall mood and emotional state")
-    health: str = Field(description="Child's physical health and well-being")
-    nutrition: str = Field(description="Summary of child's meals and eating behavior")
-    activities: List[str] = Field(description="Main activities the child engaged in")
-    social: str = Field(description="Child's interactions with peers and teachers")
-    special: str = Field(description="Special achievements or unusual occurrences")
-    keywords: List[str] = Field(
-        description="Important keywords from entities other than name entities"
-    )
+    is_valid: bool = Field(..., description="Whether the report is valid")
+    name: Optional[str] = Field(None, description="Child's name")
+    emotion: Optional[str] = Field(None, description="Child's overall mood and emotional state")
+    health: Optional[str] = Field(None, description="Child's physical health and well-being")
+    nutrition: Optional[str] = Field(None, description="Summary of child's meals and eating behavior")
+    activities: Optional[List[str]] = Field(None, description="Main activities the child engaged in")
+    social: Optional[str] = Field(None, description="Child's interactions with peers and teachers")
+    special: Optional[str] = Field(None, description="Special achievements or unusual occurrences")
+    keywords: Optional[List[str]] = Field(None, description="Important keywords from entities other than name entities")

--- a/app/api/babydiary/prompts.py
+++ b/app/api/babydiary/prompts.py
@@ -6,14 +6,19 @@ Please analyze the following daycare report and provide a summary of the child's
 Daycare Report:
 {report}
 
-Please format your response as a JSON object with the following keys: emotion, health, nutrition, activities, social, special, and keywords. 
-The 'activities' and 'keywords' fields should be lists.
+Please consider the following criteria:
+1. Does the text contain information about a child's activities, meals, or experiences in a daycare setting?
+2. Is the text written in a style typical of a daycare report?
+3. Does the text include details that would be relevant to parents about their child's day?
+
+Respond with a JSON object containing a single key "is_valid" with a boolean value (true if it's a valid daycare report, false if it's not).
 
 {format_instructions}
 
 You are 7 years old and attending kindergarten.  
 Write the diary as if the child is addressing their parents, using a warm and detailed tone. 
 Express the child's emotions and experiences vividly, and highlight any special moments.
+Always write the content corresponding to each keyword in Korean.
 
 
 """


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
[Branch][feature/babydiary-invalid-input-res-non]]

### 💡 작업동기
- 알림장 요약 API에 입력되는 유효하지 않은 입력값(ex. "aaa" -> 환각 & 영어로 알림장 요약 작성) 탐지하여 error raise 필요.
- 프론트에서 아이 알림장 요약 정보 표시할 때 키워드 내용 처리 용이하게 Response 값 Optional로 None 가능하게 변경 필요.

### 🔑 주요 변경사항
- babydiary response(models.py: DaycareReport)
   - Optional -> 해당 키워드에 내용 없을 경우 None
   - is_valid 키 값 추가하여 유효하지 않은 입력인지 검사 -> 유효하지 않다면 error raise(diary 작성 X)

### 🏞 스크린샷
#### Request
```bash
{
  "user_id": 0,
  "baby_id": 0,
  "report": "무궁화 백두산이"
}
```

#### Response
```bash
{
  "detail": "400: Invalid daycare report content"
}
```

### 관련 이슈
- #55 

### 💬리뷰 요구사항(선택)
